### PR TITLE
rename runtimeValidator to functionValidator

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ First visit [Twilio Function Configuration](https://www.twilio.com/console/runti
 Then in your Twilio Function, wrap your main `handler` with this validator:
 
 ```js
-const TokenValidator = require('twilio-flex-token-validator').runtimeValidator;
+const TokenValidator = require('twilio-flex-token-validator').functionValidator;
 
 exports.handler = TokenValidator(function(context, event, callback) {
     // Your normal Twilio Function goes here.

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1,4 +1,4 @@
-import { runtimeValidator, validator, Context, Event } from './index';
+import { functionValidator, validator, Context, Event } from './index';
 import * as nock from 'nock';
 
 // jest.mock('https');
@@ -106,7 +106,7 @@ describe('index.ts', () => {
         });
     });
 
-    describe('runtimeValidator', () => {
+    describe('functionValidator', () => {
         const context: Context = {
             ACCOUNT_SID: 'AC123',
             AUTH_TOKEN: 'AUTH123',
@@ -130,7 +130,7 @@ describe('index.ts', () => {
                 setBody
             }));
 
-            await runtimeValidator(fn)(context, event, cb);
+            await functionValidator(fn)(context, event, cb);
 
             expect(fn).not.toHaveBeenCalled();
             expect(cb).toHaveBeenCalledTimes(1);
@@ -148,7 +148,7 @@ describe('index.ts', () => {
             const fn = jest.fn();
             const cb = jest.fn();
 
-            await runtimeValidator(fn)(context, event, cb);
+            await functionValidator(fn)(context, event, cb);
 
             expect(fn).toHaveBeenCalledTimes(1);
             expect(cb).not.toHaveBeenCalled();

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,10 +16,11 @@ export type Callback = (error: any, response: any) => void;
 export type HandlerFn = (context: Context, event: Event, callback: Callback) => void;
 
 /**
- * Validator function decorator used in Twilio Functions. Calls {@link validator}
+ * A validator to be used with Twilio Function. It uses the {@link validator} to validate the token
+ *
  * @param handlerFn    the Twilio Runtime Handler Function
  */
-export const runtimeValidator = (handlerFn: HandlerFn): HandlerFn => {
+export const functionValidator = (handlerFn: HandlerFn): HandlerFn => {
     // tslint:disable-next-line
     return function(context, event, callback) {
         const failedResponse = (message: string) => {


### PR DESCRIPTION
Rename `runtimeValidator` to `functionValidator`