### PR TITLE
return the err

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -45,9 +45,7 @@ export const functionValidator = (handlerFn: HandlerFn): HandlerFn => {
                 event.TokenResult = result;
                 return handlerFn(context, event, callback);
             })
-            .catch((err) => {
-                failedResponse(err.message);
-            });
+            .catch(failedResponse);
     };
 };
 


### PR DESCRIPTION
* Error message is already converted to `message`; no need to `error.message`