### PR TITLE
Adding API Key Support (Closes #18)

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,12 +49,28 @@ You can also use this validator inside any existing Node servers:
 const TokenValidator = require('twilio-flex-token-validator').validator;
 
 TokenValidator(token, accountSid, authToken)
-    .then(tokenResult => {
-      // validated
-    })
-    .catch(err => {
-      // validation failed
-    });
+  .then(tokenResult => {
+    // validated
+  })
+  .catch(err => {
+    // validation failed
+  });
+```
+
+You can use a [Twilio API Key](https://www.twilio.com/console/runtime/api-keys) instead of directly using the root auth token. We recommend doing this because API keys are easier to revoke and rotate.
+
+```js
+const TokenValidator = require('twilio-flex-token-validator').validator;
+
+TokenValidator(token, apiKey, apiSecret, {
+  accountSid: yourAccountSid
+})
+  .then(tokenResult => {
+    // validated
+  })
+  .catch(err => {
+    // validation failed
+  });
 ```
 
 ## Token Result


### PR DESCRIPTION
Adds in API key support to flex-token-validator.

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.