### PR TITLE
Added API Key support that allows the user to optionally replace an authToken with API Keys

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -39,7 +39,7 @@ describe('index.ts', () => {
       try {
         await validator('token-123', '', '');
       } catch (err) {
-        expect(err).toContain('Unauthorized: AccountSid or a Credential (AuthToken or APIKey Object) was not provided');
+        expect(err).toContain('Unauthorized: AccountSid or API Credential was not provided');
         done();
       }
     });
@@ -48,7 +48,7 @@ describe('index.ts', () => {
       try {
         await validator('token-123', 'AC123', '');
       } catch (err) {
-        expect(err).toContain('Unauthorized: AccountSid or a Credential (AuthToken or APIKey Object) was not provided');
+        expect(err).toContain('Unauthorized: AccountSid or API Credential was not provided');
         done();
       }
     });

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -20,6 +20,7 @@ describe('index.ts', () => {
   const testToken = 'testToken';
   const replySuccessMessage = '{"valid":true, "other": "parameter"}';
   const testAccpuntSid = 'AC123';
+  const unauthorizedNoAccountSidOrAuthMessage = 'Unauthorized: AccountSid or API credential was not provided';
 
   const mockHttps = () => {
     return nock(iamUrl).post(() => true);
@@ -43,25 +44,25 @@ describe('index.ts', () => {
       try {
         await validator(testToken, '', '');
       } catch (err) {
-        expect(err).toContain('Unauthorized: AccountSid or API Credential was not provided');
+        expect(err).toContain(unauthorizedNoAccountSidOrAuthMessage);
         done();
       }
     });
 
     it('should fail if no authToken is provided', async (done) => {
       try {
-        await validator(testToken, testAccpuntSid, '');
+        await validator(testToken, testAccpuntSid, undefined);
       } catch (err) {
-        expect(err).toContain('Unauthorized: AccountSid or API Credential was not provided');
+        expect(err).toContain(unauthorizedNoAccountSidOrAuthMessage);
         done();
       }
     });
 
-    it('should fail if credential is object with out a key and secret property', async (done) => {
+    it('should fail if credential is object without properties: key and secret', async (done) => {
       try {
         await validator(testToken, testAccpuntSid, {});
       } catch (err) {
-        expect(err).toContain('Unauthorized: Missing Props - key and secret for API Credential was not provided');
+        expect(err).toContain('Unauthorized: API credential missing props - key and secret');
         done();
       }
     });
@@ -112,7 +113,7 @@ describe('index.ts', () => {
       expect(scope.isDone()).toBeTruthy();
     });
 
-    it('should validate wjen replacing authToken with API Keys', async () => {
+    it('should validate when replacing authToken with API Keys', async () => {
       const scope = nock(iamUrl).post(validationPath, { token: testToken }).reply(200, replySuccessMessage);
 
       const response = await validator(testToken, testAccpuntSid, { key: 'key-123', secret: 'secret-098' });

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -39,7 +39,7 @@ describe('index.ts', () => {
       try {
         await validator('token-123', '', '');
       } catch (err) {
-        expect(err).toContain('Unauthorized: AccountSid or AuthToken was not provided');
+        expect(err).toContain('Unauthorized: AccountSid or a Credential (AuthToken or APIKey Object) was not provided');
         done();
       }
     });
@@ -48,7 +48,7 @@ describe('index.ts', () => {
       try {
         await validator('token-123', 'AC123', '');
       } catch (err) {
-        expect(err).toContain('Unauthorized: AccountSid or AuthToken was not provided');
+        expect(err).toContain('Unauthorized: AccountSid or a Credential (AuthToken or APIKey Object) was not provided');
         done();
       }
     });

--- a/src/index.ts
+++ b/src/index.ts
@@ -32,14 +32,18 @@ export type APIKey = { secret: string; key: string };
  * @param accountSid   the accountSid
  * @param credential   the {@link AuthToken} or {@link APIKey}
  */
-export const validator = async (token: string, accountSid: string, credential: APIKey | AuthToken): Promise<object> => {
+export const validator = async (
+  token: string,
+  accountSid: string,
+  credential: APIKey | AuthToken | any,
+): Promise<object> => {
   return new Promise((resolve, reject) => {
     if (!token) {
       reject('Unauthorized: Token was not provided');
       return;
     }
 
-    if (!accountSid || accountSid.slice(0, 2) === 'AC' || !credential || credential !== '') {
+    if (!accountSid || accountSid !== '' || !credential || credential !== '') {
       reject('Unauthorized: AccountSid or a Credential (AuthToken or APIKey Object) was not provided');
       return;
     }
@@ -74,7 +78,7 @@ export const validator = async (token: string, accountSid: string, credential: A
           } else {
             reject(result.message);
           }
-        } catch (err) {
+        } catch (err: any) {
           reject(err.message);
         }
       });

--- a/src/index.ts
+++ b/src/index.ts
@@ -39,7 +39,7 @@ export const validator = async (token: string, accountSid: string, credential: A
       return;
     }
 
-    if (!accountSid || !credential) {
+    if (!accountSid || accountSid.slice(0, 2) === 'AC' || !credential || credential !== '') {
       reject('Unauthorized: AccountSid or a Credential (AuthToken or APIKey Object) was not provided');
       return;
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -43,7 +43,7 @@ export const validator = async (
       return;
     }
 
-    if (!accountSid || accountSid !== '' || !credential || credential !== '') {
+    if (!accountSid || accountSid === '' || !credential || credential === '') {
       reject('Unauthorized: AccountSid or a Credential (AuthToken or APIKey Object) was not provided');
       return;
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -42,8 +42,13 @@ export const validator = async (token: string, accountSid: string, authToken: st
       reject('Unauthorized: AccountSid or AuthToken was not provided');
       return;
     }
+    
+    // detects if authToken is an object with attributes key and secret to assign hasAPIKey a boolean 
+    const hasAPIKey = !!apikeys ? (!!apikeys.key ? (!!apikeys.secret ? true : false ) : false) : false;
 
-    const authorization = Buffer.from(`${accountSid}:${authToken}`);
+    // changed to include API keys if hasAPIKey is true
+    const authorization = hasAPIKeys ? Buffer.from(`${apikeys.key}:${apikeys.secret}` : Buffer.from(`${accountSid}:${authToken}`);
+
     const requestData = JSON.stringify({ token });
     const requestOption = {
       hostname: 'iam.twilio.com',
@@ -52,9 +57,6 @@ export const validator = async (token: string, accountSid: string, authToken: st
       method: 'POST',
       headers: {
         Authorization: `Basic ${authorization.toString('base64')}`,
-        'Cache-Control': 'no-cache',
-        'Content-Type': 'application/json',
-        'Content-Length': requestData.length,
       },
     };
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -23,31 +23,33 @@ export interface Event {
 
 export type Callback = (error: any, response: Twilio.Response) => void;
 export type HandlerFn = (context: Context, event: Event, callback: Callback) => void;
-
+export type AuthToken = string;
+export type APIKey = {secret: string, key: string};
 /**
  * Validates that the Token is valid
  *
  * @param token        the token to validate
  * @param accountSid   the accountSid
- * @param authToken    the authToken
+ * @param credential    the authToken
  */
-export const validator = async (token: string, accountSid: string, authToken: string): Promise<object> => {
+export const validator = async (token: string, accountSid: string, credential: APIKey | AuthToken): Promise<object> => {
   return new Promise((resolve, reject) => {
     if (!token) {
       reject('Unauthorized: Token was not provided');
       return;
     }
 
-    if (!accountSid || !authToken) {
+    if (!accountSid || !credential) {
       reject('Unauthorized: AccountSid or AuthToken was not provided');
       return;
     }
     
-    // detects if authToken is an object with attributes key and secret to assign hasAPIKey a boolean 
-    const hasAPIKey = !!apikeys ? (!!apikeys.key ? (!!apikeys.secret ? true : false ) : false) : false;
+    const hasAPIKey = credential && typeof credential === 'object' && credential.secret && credential.key;
 
     // changed to include API keys if hasAPIKey is true
-    const authorization = hasAPIKeys ? Buffer.from(`${apikeys.key}:${apikeys.secret}` : Buffer.from(`${accountSid}:${authToken}`);
+    const authorization = hasAPIKey 
+      ? Buffer.from(`${credential.key}:${credential.secret}`) 
+      : Buffer.from(`${accountSid}:${credential}`);
 
     const requestData = JSON.stringify({ token });
     const requestOption = {

--- a/src/index.ts
+++ b/src/index.ts
@@ -56,7 +56,10 @@ export const validator = async (token: string, accountSid: string, authToken: st
       path: `/v1/Accounts/${accountSid}/Tokens/validate`,
       method: 'POST',
       headers: {
-        Authorization: `Basic ${authorization.toString('base64')}`,
+        'Authorization': `Basic ${authorization.toString('base64')}`,
+        'Cache-Control': 'no-cache',
+        'Content-Type': 'application/json',
+        'Content-Length': requestData.length,
       },
     };
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -48,10 +48,14 @@ export const validator = async (
       return;
     }
 
+    if ((typeof credential === 'object') === (!credential.key || !credential.secret)) {
+      reject('Unauthorized: Missing Props - key and secret for API Credential was not provided');
+      return;
+    }
+
     const key = typeof credential === 'object' ? credential.key : accountSid;
     const secret = typeof credential === 'object' ? credential.secret : credential;
     const authorization = Buffer.from(`${key}:${secret}`);
-
     const requestData = JSON.stringify({ token });
     const requestOption = {
       hostname: 'iam.twilio.com',

--- a/src/index.ts
+++ b/src/index.ts
@@ -44,7 +44,7 @@ export const validator = async (
     }
 
     if (!accountSid || accountSid === '' || !credential || credential === '') {
-      reject('Unauthorized: AccountSid or a Credential (AuthToken or APIKey Object) was not provided');
+      reject('Unauthorized: AccountSid or API Credential was not provided');
       return;
     }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -44,11 +44,9 @@ export const validator = async (token: string, accountSid: string, credential: A
       return;
     }
 
-    const hasAPIKey = credential && typeof credential === 'object' && credential.secret && credential.key;
-
-    const authorization = hasAPIKey
-      ? Buffer.from(`${credential.key}:${credential.secret}`)
-      : Buffer.from(`${accountSid}:${credential}`);
+    const key = typeof credential === 'object' ? credential.key : accountSid;
+    const secret = typeof credential === 'object' ? credential.secret : credential;
+    const authorization = Buffer.from(`${key}:${secret}`);
 
     const requestData = JSON.stringify({ token });
     const requestOption = {

--- a/src/index.ts
+++ b/src/index.ts
@@ -24,13 +24,13 @@ export interface Event {
 export type Callback = (error: any, response: Twilio.Response) => void;
 export type HandlerFn = (context: Context, event: Event, callback: Callback) => void;
 export type AuthToken = string;
-export type APIKey = {secret: string, key: string};
+export type APIKey = { secret: string; key: string };
 /**
  * Validates that the Token is valid
  *
  * @param token        the token to validate
  * @param accountSid   the accountSid
- * @param credential    the authToken
+ * @param credential   the {@link AuthToken} or {@link APIKey}
  */
 export const validator = async (token: string, accountSid: string, credential: APIKey | AuthToken): Promise<object> => {
   return new Promise((resolve, reject) => {
@@ -40,15 +40,14 @@ export const validator = async (token: string, accountSid: string, credential: A
     }
 
     if (!accountSid || !credential) {
-      reject('Unauthorized: AccountSid or AuthToken was not provided');
+      reject('Unauthorized: AccountSid or a Credential (AuthToken or APIKey Object) was not provided');
       return;
     }
-    
+
     const hasAPIKey = credential && typeof credential === 'object' && credential.secret && credential.key;
 
-    // changed to include API keys if hasAPIKey is true
-    const authorization = hasAPIKey 
-      ? Buffer.from(`${credential.key}:${credential.secret}`) 
+    const authorization = hasAPIKey
+      ? Buffer.from(`${credential.key}:${credential.secret}`)
       : Buffer.from(`${accountSid}:${credential}`);
 
     const requestData = JSON.stringify({ token });
@@ -58,7 +57,7 @@ export const validator = async (token: string, accountSid: string, credential: A
       path: `/v1/Accounts/${accountSid}/Tokens/validate`,
       method: 'POST',
       headers: {
-        'Authorization': `Basic ${authorization.toString('base64')}`,
+        Authorization: `Basic ${authorization.toString('base64')}`,
         'Cache-Control': 'no-cache',
         'Content-Type': 'application/json',
         'Content-Length': requestData.length,

--- a/src/index.ts
+++ b/src/index.ts
@@ -42,14 +42,13 @@ export const validator = async (
       reject('Unauthorized: Token was not provided');
       return;
     }
-
-    if (!accountSid || accountSid === '' || !credential || credential === '') {
-      reject('Unauthorized: AccountSid or API Credential was not provided');
+    if (!accountSid || !credential) {
+      reject('Unauthorized: AccountSid or API credential was not provided');
       return;
     }
 
     if ((typeof credential === 'object') === (!credential.key || !credential.secret)) {
-      reject('Unauthorized: Missing Props - key and secret for API Credential was not provided');
+      reject('Unauthorized: API credential missing props - key and secret');
       return;
     }
 


### PR DESCRIPTION
><!-- Describe your Pull Request -->
A small non-breaking update for replacing the `authToken` parameter with *APIKeys*. Using API keys with limited permissions over an  **AuthToken** is better practice and the changes added here will allow an object with API Keys to replace the *AuthToken* argument.  

> how to:

Replace the `authToken` parameter with an object initialized with the attributes `key` and ` secret` .  

eg 
`{ key: 'SK##########', secret: '!@#$%^&*()' }`

```javascript
TokenValidator(token, accountSid, { key: 'SK##########', secret: '!@#$%^&*()' })
    .then(tokenResult => {
      // validated
    })
    .catch(err => {
      // validation failed
    });
```
 
**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [ x] I acknowledge that all my contributions will be made under the project's license.
