### PR TITLE
adding support for realm stage/dev

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -116,10 +116,9 @@ export const functionValidator = (handlerFn: HandlerFn): HandlerFn => {
         'Unauthorized: AccountSid or AuthToken was not provided. For more information, please visit https://twilio.com/console/runtime/functions/configure',
       );
     }
-    let twilioRegion = null;
-    if (context.TWILIO_REGION) twilioRegion = context.TWILIO_REGION.split('-');
-    const realm = twilioRegion ? twilioRegion[0] : '';
-    return validator(token, accountSid, authToken, realm)
+
+    const region = context.TWILIO_REGION ? context.TWILIO_REGION.split('-')[0] : '';
+    return validator(token, accountSid, authToken, region)
       .then((result) => {
         event.TokenResult = result;
         return handlerFn(context, event, callback);

--- a/src/index.ts
+++ b/src/index.ts
@@ -111,8 +111,10 @@ export const functionValidator = (handlerFn: HandlerFn): HandlerFn => {
         'Unauthorized: AccountSid or AuthToken was not provided. For more information, please visit https://twilio.com/console/runtime/functions/configure',
       );
     }
-    const twilioRegion = context.TWILIO_REGION.split("-")
-    const realm = twilioRegion.length > 0 ? twilioRegion[0] : '';
+    let twilioRegion = null;
+    if(context.TWILIO_REGION)
+      twilioRegion = context.TWILIO_REGION.split("-");
+    const realm = twilioRegion ? twilioRegion[0] : '';
     return validator(token, accountSid, authToken, realm)
       .then((result) => {
         event.TokenResult = result;

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,7 +14,7 @@ declare namespace Twilio {
 export interface Context {
   ACCOUNT_SID: string;
   AUTH_TOKEN: string;
-  TWILIO_REGION: string;
+  TWILIO_REGION?: string;
 }
 
 export interface Event {
@@ -32,7 +32,12 @@ export type HandlerFn = (context: Context, event: Event, callback: Callback) => 
  * @param accountSid   the accountSid
  * @param authToken    the authToken
  */
-export const validator = async (token: string, accountSid: string, authToken: string, realm?: string): Promise<object> => {
+export const validator = async (
+  token: string,
+  accountSid: string,
+  authToken: string,
+  realm?: string,
+): Promise<object> => {
   return new Promise((resolve, reject) => {
     if (!token) {
       reject('Unauthorized: Token was not provided');
@@ -112,8 +117,7 @@ export const functionValidator = (handlerFn: HandlerFn): HandlerFn => {
       );
     }
     let twilioRegion = null;
-    if(context.TWILIO_REGION)
-      twilioRegion = context.TWILIO_REGION.split("-");
+    if (context.TWILIO_REGION) twilioRegion = context.TWILIO_REGION.split('-');
     const realm = twilioRegion ? twilioRegion[0] : '';
     return validator(token, accountSid, authToken, realm)
       .then((result) => {


### PR DESCRIPTION
Currently the package works with only production because the iam URL is fixed for production only.

Made changes to pick TWILIO_REGION environment variable from serverless context and extract realm from it and augment iam URL for token validation

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [ ] I acknowledge that all my contributions will be made under the project's license.
